### PR TITLE
Switch to using GITHUB_ACTOR

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -1,5 +1,5 @@
 github:
-  username: ${{ secrets.GITHUB_USERNAME }}
+  username: ${{ secrets.GITHUB_ACTOR }}
   token:    ${{ secrets.GITHUB_TOKEN }}
 
 codeowners:

--- a/.github/workflows/update-pipeline.yml
+++ b/.github/workflows/update-pipeline.yml
@@ -64,7 +64,7 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             - uses: peter-evans/create-pull-request@v4
               with:
-                author: ${{ secrets.GITHUB_USERNAME }} <${{ secrets.GITHUB_USERNAME }}@users.noreply.github.com>
+                author: ${{ secrets.GITHUB_ACTOR }} <${{ secrets.GITHUB_ACTOR }}@users.noreply.github.com>
                 body: |-
                     Bumps pipeline from `${{ steps.pipeline.outputs.old-version }}` to `${{ steps.pipeline.outputs.new-version }}`.
 


### PR DESCRIPTION
Switch to using GITHUB_ACTOR as the username represented in the commit log for entries created by the pipeline.

Resolves #2

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>