### PR TITLE
Change GHA user

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -1,6 +1,6 @@
 github:
-  username: buildpack-bot
-  token:    ${{ secrets.GITHUB_TOKEN }}
+  username: ${{ secrets.IMPLEMENTATION_GITHUB_USERNAME }}
+  token:    ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}
 
 codeowners:
 - path:  "*"

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -214,7 +214,7 @@ jobs:
                   --field "body=${RELEASE_BODY//<!-- DIGEST PLACEHOLDER -->/\`${DIGEST}\`}"
               env:
                 DIGEST: ${{ steps.package.outputs.digest }}
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}
             - if: ${{ true }}
               uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1
               with:

--- a/.github/workflows/pb-synchronize-labels.yml
+++ b/.github/workflows/pb-synchronize-labels.yml
@@ -5,6 +5,7 @@ name: Synchronize Labels
             - main
         paths:
             - .github/labels.yml
+    workflow_dispatch: {}
 jobs:
     synchronize:
         name: Synchronize Labels
@@ -14,4 +15,4 @@ jobs:
             - uses: actions/checkout@v3
             - uses: micnncim/action-label-syncer@v1
               env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-draft-release.yml
+++ b/.github/workflows/pb-update-draft-release.yml
@@ -12,12 +12,12 @@ jobs:
             - id: release-drafter
               uses: release-drafter/release-drafter@v5
               env:
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}
             - uses: actions/checkout@v3
             - name: Update draft release with buildpack information
               uses: docker://ghcr.io/paketo-buildpacks/actions/draft-release:main
               with:
-                github_token: ${{ secrets.GITHUB_TOKEN }}
+                github_token: ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}
                 release_body: ${{ steps.release-drafter.outputs.body }}
                 release_id: ${{ steps.release-drafter.outputs.id }}
                 release_name: ${{ steps.release-drafter.outputs.name }}

--- a/.github/workflows/pb-update-go.yml
+++ b/.github/workflows/pb-update-go.yml
@@ -41,7 +41,7 @@ jobs:
                 GO_VERSION: "1.18"
             - uses: peter-evans/create-pull-request@v4
               with:
-                author: buildpack-bot <buildpack-bot@users.noreply.github.com>
+                author: ${{ secrets.IMPLEMENTATION_GITHUB_USERNAME }} <${{ secrets.IMPLEMENTATION_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: |-
                     Bumps Go from `${{ steps.update-go.outputs.old-go-version }}` to `${{ steps.update-go.outputs.go-version }}`.
 
@@ -58,4 +58,4 @@ jobs:
                 labels: semver:minor, type:task
                 signoff: true
                 title: Bump Go from ${{ steps.update-go.outputs.old-go-version }} to ${{ steps.update-go.outputs.go-version }}
-                token: ${{ secrets.GITHUB_TOKEN }}
+                token: ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -62,10 +62,10 @@ jobs:
                 echo "::set-output name=release-notes::${RELEASE_NOTES//$'\n'/%0A}"
               env:
                 DESCRIPTOR: .github/pipeline-descriptor.yml
-                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GITHUB_TOKEN: ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}
             - uses: peter-evans/create-pull-request@v4
               with:
-                author: buildpack-bot <buildpack-bot@users.noreply.github.com>
+                author: ${{ secrets.IMPLEMENTATION_GITHUB_USERNAME }} <${{ secrets.IMPLEMENTATION_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: |-
                     Bumps pipeline from `${{ steps.pipeline.outputs.old-version }}` to `${{ steps.pipeline.outputs.new-version }}`.
 
@@ -82,4 +82,4 @@ jobs:
                 labels: semver:patch, type:task
                 signoff: true
                 title: Bump pipeline from ${{ steps.pipeline.outputs.old-version }} to ${{ steps.pipeline.outputs.new-version }}
-                token: ${{ secrets.GITHUB_TOKEN }}
+                token: ${{ secrets.IMPLEMENTATION_GITHUB_TOKEN }}


### PR DESCRIPTION
Changes the user token used by GHAs. Previously, we were using 'GITHUB_TOKEN', but this seems to be causing issues trigger other pipelines to run, like here: https://github.com/buildpacks/profile/pull/15. The actions never ran, so the PR couldn't be approved and merged.

Using the separate user should bypass the restrictions on the default token & allow dispatching the other workflows.

More context [here](https://cloud-native.slack.com/archives/C0333LG1E68/p1661182759826889).

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>